### PR TITLE
Fixes "conflicting declaration of C function"

### DIFF
--- a/controller.cpp
+++ b/controller.cpp
@@ -1,14 +1,11 @@
-extern "C"
-{
-#include "raylib.h"
-#include "raymath.h"
 #define RAYGUI_IMPLEMENTATION
 #include "raygui.h"
-}
 #if defined(PLATFORM_WEB)
 #include <emscripten/emscripten.h>
 #endif
 
+#include "raylib.h"
+#include "raymath.h"
 #include "common.h"
 #include "vec.h"
 #include "quat.h"


### PR DESCRIPTION
"extern C" generates compilation errors. 
Actually, it's already handled in raylib.h: https://github.com/raysan5/raylib/blob/master/src/raylib.h#L968-L970

Should these lines be removed?

![Captura de tela 2025-02-05 235359](https://github.com/user-attachments/assets/fb90cdb0-decb-4ad2-bc69-9f97c44e3b24)
